### PR TITLE
Orbs aws ecr - Fixed pip v19.0 error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
   build_test_deploy:
     jobs:
       - build_test
-      - docker_hub_build_and_push_image:
+      - docker_hub_build_push_image:
           requires:
             - build_test
       - aws-ecr/build_and_push_image:
@@ -34,7 +34,7 @@ jobs:
           command: |
             . helloworld/bin/activate
             python test_hello_world.py
-  docker_hub_build__push_image:
+  docker_hub_build_push_image:
     docker:
       - image: circleci/python:2.7.14
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
           command: |
             virtualenv helloworld
             . helloworld/bin/activate
+            pip install --user --upgrade pip==18.0.0
             pip install --no-cache-dir -r requirements.txt
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           name: Setup VirtualEnv
           command: |
             pip install --user --upgrade pip==18.0.0
-            pip install --no-cache-dir -r requirements.txt
+            pip install --user --no-cache-dir -r requirements.txt
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
       - run:
           name: Setup VirtualEnv
           command: |
+            pip install --user --upgrade pip==18.0.0
             virtualenv helloworld
             . helloworld/bin/activate
-            pip install --user --upgrade pip==18.0.0
             pip install --no-cache-dir -r requirements.txt
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
       - aws-ecr/build_and_push_image:
           region: us-east-1
           account-url: ${AWS_ECR_ACCOUNT_URL}
-          repo: $CIRCLE_PROJECT_REPONAME
+          repo: ${CIRCLE_PROJECT_REPONAME}
           tag: ${CIRCLE_BUILD_NUM}
           requires:
             - build_test
@@ -45,7 +45,7 @@ jobs:
           name: Build and push Docker image to Docker Hub
           command: |
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> ${BASH_ENV}
-            echo 'export IMAGE_NAME=${$CIRCLE_PROJECT_REPONAME}' >> ${BASH_ENV}
+            echo 'export IMAGE_NAME=${CIRCLE_PROJECT_REPONAME}' >> ${BASH_ENV}
             source ${BASH_ENV}
             docker build -t ${DOCKER_LOGIN}/${IMAGE_NAME} -t ${DOCKER_LOGIN}/${IMAGE_NAME}:${TAG} .
             echo ${DOCKER_PWD} | docker login -u ${DOCKER_LOGIN} --password-stdin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Build and push Docker image to Docker Hub
           command: |
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> ${BASH_ENV}
-            echo 'export IMAGE_NAME=orbs-ecr-python' >> ${BASH_ENV}
+            echo 'export IMAGE_NAME=${$CIRCLE_PROJECT_REPONAME}' >> ${BASH_ENV}
             source ${BASH_ENV}
             docker build -t ${DOCKER_LOGIN}/${IMAGE_NAME} -t ${DOCKER_LOGIN}/${IMAGE_NAME}:${TAG} .
             echo ${DOCKER_PWD} | docker login -u ${DOCKER_LOGIN} --password-stdin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,13 +27,10 @@ jobs:
           name: Setup VirtualEnv
           command: |
             pip install --user --upgrade pip==18.0.0
-            virtualenv helloworld
-            . helloworld/bin/activate
             pip install --no-cache-dir -r requirements.txt
       - run:
           name: Run Tests
           command: |
-            . helloworld/bin/activate
             python test_hello_world.py
   docker_hub_build_push_image:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7.14
 COPY requirements.txt .
 COPY hello_world.py .
 RUN mkdir /opt/hello_world/
-RUN pip install --upgrade pip \
+RUN pip install --user --upgrade pip==18.0.0 \
     && pip install --no-cache-dir -r requirements.txt \
     && pyinstaller -F hello_world.py \
     && cp dist/hello_world /opt/hello_world/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7.14
 COPY requirements.txt .
 COPY hello_world.py .
 RUN mkdir /opt/hello_world/
-RUN pip install --user --upgrade pip==18.0.0 \
+RUN pip install --upgrade pip==18.0.0 \
     && pip install --no-cache-dir -r requirements.txt \
     && pyinstaller -F hello_world.py \
     && cp dist/hello_world /opt/hello_world/


### PR DESCRIPTION
The python pip client version 19.0 has bug in it that doesn't allow the installation of certain packages suhc as pyinstaller & flask. My research shows that there is a bug in pipv19 that is causing this issue. 

As a work around I downgraded pip to version 18.0 and the packages are installing again

I have implemented a workaround that stops using VirtualEnv and downgrades the pip client to v18.0